### PR TITLE
feat: エラーとlistenerの型定義を作った

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -1,19 +1,30 @@
-export type JoinRoomData = {
-  pageId: string | null;
+export type JoinRoomRequest =
+  | JoinPageRoomRequest
+  | JoinProjectRoomRequest
+  | JoinStreamRoomRequest;
+
+export interface JoinProjectRoomRequest {
+  pageId: null;
   projectId: string;
   projectUpdatesStream: false;
-} | {
+}
+
+export interface JoinPageRoomRequest {
+  pageId: string;
+  projectId: string;
+  projectUpdatesStream: false;
+}
+
+export interface JoinStreamRoomRequest {
   pageId: null;
   projectId: string;
   projectUpdatesStream: true;
-};
+}
 
 export interface JoinRoomResponse {
-  data: {
-    success: true;
-    pageId: string | null;
-    projectId: string;
-  };
+  success: true;
+  pageId: string | null;
+  projectId: string;
 }
 
 export interface ProjectUpdatesStreamCommit {
@@ -23,85 +34,180 @@ export interface ProjectUpdatesStreamCommit {
   projectId: string;
   pageId: string;
   userId: string;
-  changes: Change[] | [Delete];
+  changes:
+    | (
+      | InsertChange
+      | UpdateChange
+      | DeleteChange
+      | TitleChange
+      | LinksChange
+      | IconsChange
+    )[]
+    | [DeletePageChange];
   cursor: null;
   freeze: true;
 }
-export type ProjectUpdatesStreamEvent =
-  & {
-    id: string;
-    pageId: string;
-    userId: string;
-    projectId: string;
-    created: number;
-    updated: number;
-  }
-  & ({
-    type: "member.join" | "invitation.reset";
-  } | {
-    type: "page.delete";
-    data: {
-      titleLc: string;
-    };
-  } | {
-    type: "admin.add" | "admin.delete" | "owner.set";
-    targetUserId: string;
-  });
 
-export interface CommitNotification {
-  kind: "page";
+export type ProjectUpdatesStreamEvent =
+  | MemberJoinEvent
+  | InvitationResetEvent
+  | PageDeleteEvent
+  | AdminAddEvent
+  | AdminDeleteEvent
+  | OwnerSetEvent;
+
+export interface ProjectEvent {
   id: string;
+  pageId: string;
+  userId: string;
+  projectId: string;
+  created: number;
+  updated: number;
+}
+
+export interface PageDeleteEvent extends ProjectEvent {
+  type: "page.delete";
+  data: {
+    titleLc: string;
+  };
+}
+
+export interface MemberJoinEvent extends ProjectEvent {
+  type: "member.join";
+}
+export interface InvitationResetEvent extends ProjectEvent {
+  type: "invitation.reset";
+}
+export interface AdminAddEvent extends ProjectEvent {
+  type: "admin.add";
+  targetUserId: string;
+}
+export interface AdminDeleteEvent extends ProjectEvent {
+  type: "admin.delete";
+  targetUserId: string;
+}
+export interface OwnerSetEvent extends ProjectEvent {
+  type: "owner.set";
+  targetUserId: string;
+}
+
+export interface CommitNotification extends PageCommit {
+  id: string;
+}
+
+export interface PageCommit {
+  kind: "page";
   parentId: string;
   projectId: string;
   pageId: string;
   userId: string;
-  changes: Change[] | [Pin] | [Delete];
-  cursor: null;
+  changes: Change[] | [PinChange] | [DeletePageChange];
+  cursor?: null;
   freeze: true;
 }
-export type CommitData = Omit<CommitNotification, "id">;
-export interface CommitResponse {
-  data: {
-    commitId: string;
-  };
+export interface PageCommitResponse {
+  commitId: string;
 }
+
+export interface ErrorLike {
+  name: string;
+}
+
+export interface UnexpectedError {
+  name: "UnexpectedError";
+  value: unknown;
+}
+export interface TimeoutError {
+  name: "TimeoutError";
+  message: string;
+}
+
+export type PageCommitError =
+  | SocketIOError
+  | DuplicateTitleError
+  | NotFastForwardError;
+
+/* the error that occurs when the socket.io causes an error
+*
+* when this error occurs, wait for a while and retry the request
+*/
+export interface SocketIOError {
+  name: "SocketIOError";
+}
+/** the error that occurs when the title is already in use */
+export interface DuplicateTitleError {
+  name: "DuplicateTitleError";
+}
+/** the error caused when commitId is not latest */
+export interface NotFastForwardError {
+  name: "NotFastForwardError";
+}
+
+export const isPageCommitError = (error: ErrorLike): error is PageCommitError =>
+  pageCommitErrorNames.includes(error.name);
+
+const pageCommitErrorNames = [
+  "SocketIOError",
+  "DuplicateTitleError",
+  "NotFastForwardError",
+];
+
+export type Result<T, E = unknown> =
+  | { ok: true; value: T }
+  | { ok: false; value: E };
+
 export interface EventMap {
   "socket.io-request": (
-    data: { method: "commit"; data: CommitData } | {
+    req: { method: "commit"; data: PageCommit } | {
       method: "room:join";
-      data: JoinRoomData;
+      data: JoinRoomRequest;
     },
-    callback: (
-      response: (CommitResponse | JoinRoomResponse) & { error?: unknown },
-    ) => void,
+    success: PageCommitResponse | JoinRoomResponse,
+    failed: PageCommitError,
   ) => void;
   cursor: (
-    data: Omit<MoveCursorData, "socketId">,
-    callback: (response: { error?: unknown }) => void,
+    req: Omit<MoveCursorData, "socketId">,
+    success: undefined,
+    failed: unknown,
   ) => void;
 }
 export interface ListenEventMap {
-  "projectUpdatesStream:commit": (
-    data: ProjectUpdatesStreamCommit,
-  ) => void;
-  "projectUpdatesStream:event": (
-    data: ProjectUpdatesStreamEvent,
-  ) => void;
-  commit: (data: CommitNotification) => void;
-  cursor: (data: MoveCursorData) => void;
+  "projectUpdatesStream:commit": ProjectUpdatesStreamCommit;
+  "projectUpdatesStream:event": ProjectUpdatesStreamEvent;
+  commit: CommitNotification;
+  cursor: MoveCursorData;
+  "quick-search:commit": QuickSearchCommit;
+  "quick-search:replace-link": QuickSearchReplaceLink;
+  "infobox:updating": boolean;
+  "infobox:reload": void;
+  "literal-database:reload": void;
 }
+
+export interface QuickSearchCommit extends Omit<CommitNotification, "changes"> {
+  changes:
+    | (TitleChange | LinksChange | DescriptionsChange | ImageChange)[]
+    | [DeletePageChange];
+}
+
+export interface QuickSearchReplaceLink {
+  from: string;
+  to: string;
+}
+
 export type DataOf<Event extends keyof EventMap> = Parameters<
   EventMap[Event]
 >[0];
-export type ResponseOf<Event extends keyof EventMap> = Parameters<
-  Parameters<
-    EventMap[Event]
-  >[1]
->[0];
+export type SuccessResOf<Event extends keyof EventMap> = Parameters<
+  EventMap[Event]
+>[1];
+export type FailedResOf<Event extends keyof EventMap> = Parameters<
+  EventMap[Event]
+>[2];
 
 export interface MoveCursorData {
   user: {
     id: string;
+    name: string;
     displayName: string;
   };
   pageId: string;
@@ -114,49 +220,66 @@ export interface MoveCursorData {
 }
 
 export type Change =
-  | InsertCommit
-  | UpdateCommit
-  | DeleteCommit
-  | LinksCommit
-  | ProjectLinksCommit
-  | DescriptionsCommit
-  | ImageCommit
-  | TitleCommit;
-export interface InsertCommit {
+  | InsertChange
+  | UpdateChange
+  | DeleteChange
+  | LinksChange
+  | ProjectLinksChange
+  | DescriptionsChange
+  | ImageChange
+  | FilesChange
+  | HelpFeelsChange
+  | infoboxDefinitionChange
+  | TitleChange;
+export interface InsertChange {
   _insert: string;
   lines: {
     id: string;
     text: string;
   };
 }
-export interface UpdateCommit {
+export interface UpdateChange {
   _update: string;
   lines: {
     text: string;
   };
+  noTimestampUpdate: unknown;
 }
-export interface DeleteCommit {
+export interface DeleteChange {
   _delete: string;
   lines: -1;
 }
-export interface LinksCommit {
+export interface LinksChange {
   links: string[];
 }
-export interface ProjectLinksCommit {
+export interface ProjectLinksChange {
   projectLinks: string[];
 }
-export interface DescriptionsCommit {
+export interface IconsChange {
+  icons: string[];
+}
+export interface DescriptionsChange {
   descriptions: string[];
 }
-export interface ImageCommit {
+export interface ImageChange {
   image: string | null;
 }
-export interface TitleCommit {
+export interface TitleChange {
   title: string;
 }
-export interface Pin {
+export interface FilesChange {
+  files: unknown[];
+}
+export interface HelpFeelsChange {
+  helpfeels: unknown[];
+}
+export interface infoboxDefinitionChange {
+  infoboxDefinition: unknown[];
+}
+export interface PinChange {
   pin: number;
 }
-export interface Delete {
+export interface DeletePageChange {
   deleted: true;
+  merged?: true;
 }


### PR DESCRIPTION
- 型の名前を破壊的に変更した
- `request`の戻り値を`Result<T, E>`に変更
  - 仕様で予測できるエラーは戻り値に入れて返す

close [⬜エラーの型定義を作る (scrapbox-userscript-websocket)](https://scrapbox.io/takker/⬜エラーの型定義を作る_(scrapbox-userscript-websocket))