### PR TITLE
fix: `UpdateChange.noTimestampUpdate` is optional

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -243,7 +243,7 @@ export interface UpdateChange {
   lines: {
     text: string;
   };
-  noTimestampUpdate: unknown;
+  noTimestampUpdate?: unknown;
 }
 export interface DeleteChange {
   _delete: string;


### PR DESCRIPTION
fix #7